### PR TITLE
Throw error when userId missing for user feed type

### DIFF
--- a/__tests__/feeds/FeedPortMastojsAdapter.unit.test.ts
+++ b/__tests__/feeds/FeedPortMastojsAdapter.unit.test.ts
@@ -1,0 +1,18 @@
+import FeedPortMastojsAdapter from "@/lib/data/adapters/feed/mastojs/FeedPortMastojsAdapter";
+import { feedTypes } from "@/lib/data/core/ports/FeedPort";
+
+// Since getRepository is a private method, access it via casting to any
+function callGetRepository(
+  adapter: FeedPortMastojsAdapter,
+  type: feedTypes,
+  userId?: string,
+) {
+  return (adapter as any)["getRepository"]({} as any, type, userId);
+}
+
+describe("FeedPortMastojsAdapter.getRepository", () => {
+  it("throws an error when user feed type is requested without userId", () => {
+    const adapter = new FeedPortMastojsAdapter();
+    expect(() => callGetRepository(adapter, feedTypes.user)).toThrow(Error);
+  });
+});

--- a/lib/data/adapters/feed/mastojs/FeedPortMastojsAdapter.ts
+++ b/lib/data/adapters/feed/mastojs/FeedPortMastojsAdapter.ts
@@ -51,9 +51,12 @@ export default class FeedPortMastojsAdapter implements FeedPort {
       case feedTypes.local:
         return client.v1.timelines.public;
       case feedTypes.user:
-        if (userId) {
-          return client.v1.accounts.$select(userId).statuses;
+        if (!userId) {
+          throw new Error(
+            `Unsupported feed type or parameters are missed for: ${type} type.`,
+          );
         }
+        return client.v1.accounts.$select(userId).statuses;
       case feedTypes.bookmark:
         return client.v1.bookmarks;
       case feedTypes.favorites:


### PR DESCRIPTION
## Summary
- validate `userId` for user feed type in feed adapter
- test error path when `userId` is not provided

## Testing
- `npm run tests` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*